### PR TITLE
Updated to Kokkos latest version (v4.4.01) & removed deprecation warnings

### DIFF
--- a/src/grid/gridstorage/kokkos-storage.hpp
+++ b/src/grid/gridstorage/kokkos-storage.hpp
@@ -100,6 +100,11 @@ namespace schnek {
       KokkosGridStorage(const KokkosGridStorage &);
 
       /**
+       * @brief Explicitly defaulting the copy assignment operator
+       */
+      KokkosGridStorage& operator=(const KokkosGridStorage&) = default;
+
+      /**
        * @brief Construct with a given size
        *
        * @param lo the lowest coordinate in the grid (inclusive)

--- a/src/grid/iteration/kokkos-iteration.hpp
+++ b/src/grid/iteration/kokkos-iteration.hpp
@@ -63,7 +63,7 @@ namespace schnek {
 
         template<typename... Indices>
         SCHNEK_INLINE void operator()(Indices... ind) const {
-          func(typename RangeType::LimitType{ind...});
+          func(typename RangeType::LimitType{static_cast<int>(ind)...});
         }
     };
   }  // namespace internal

--- a/testsuite/main.cpp
+++ b/testsuite/main.cpp
@@ -19,9 +19,13 @@ class KokkosInitialiser
 
     KokkosInitialiser() {
         std::cerr << "KOKKOS INIT\n";
-        Kokkos::InitArguments args;
-        args.num_threads = 0;
-        args.num_numa = 0;
+
+        Kokkos::InitializationSettings args;
+        
+        args.set_num_threads(0);
+        args.set_map_device_id_by("random");    // selects a random device from the available devices
+        // args.set_map_device_id_by("mpi_rank");  // selects a device based on assignment of local mpi ranks
+        
         Kokkos::initialize(args);
     }
 


### PR DESCRIPTION
1. Upgraded to Kokkos v4.4.01
2. Resolved a implicit declaration deprecation warning by explicitly defaulting the copy assignment operator in the kokkos storage class
3. Resolved -Wnarrowing warning for narrowing conversion from long int to int in the kokkos iteration header file by using static_cast type conversion